### PR TITLE
Bugfix - Vite Config Base URL

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: 'https://rpire.github.io/',
+  base: '/portfolio/',
 });


### PR DESCRIPTION
This PR changed the base value from `https://rpire.github.io/` to `/portfolio/` in the vite.config.ts file.

Closes #19 
